### PR TITLE
Fix function name mismatch causing panic in create_makasero_enhanceme…

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -183,7 +183,7 @@ var builtinFunctions = map[string]FunctionDefinition{
 		},
 		Handler: handleGhIssueCreate,
 	},
-	"create_enhancement_issue": {
+	"create_makasero_enhancement_issue": {
 		Declaration: &genai.FunctionDeclaration{
 			Name:        "create_makasero_enhancement_issue",
 			Description: "makasero 自身の改善案を GitHub Issue として起票します。issue は pankona/makasero リポジトリの issue として起票され、自動的に 'enhancement' ラベルが付与されます。",


### PR DESCRIPTION
…nt_issue

- Changed map key from "create_enhancement_issue" to "create_makasero_enhancement_issue"
- This aligns the map key with the function declaration name
- Fixes panic in agent.go:245 when calling the function via function calling

Fixes #52