### PR TITLE
refactor: move SessionDir from global variable to Agent member field

### DIFF
--- a/session.go
+++ b/session.go
@@ -1,6 +1,7 @@
 package makasero
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/generative-ai-go/genai"
+	"github.com/pankona/makasero/mlog"
 )
 
 // SessionDir はセッションファイルを保存するディレクトリパスです。

--- a/session.go
+++ b/session.go
@@ -188,7 +188,7 @@ func ListSessionsFromDir(sessionDir string) ([]*Session, error) {
 			id := strings.TrimSuffix(entry.Name(), ".json")
 			session, err := LoadSessionFromDir(sessionDir, id)
 			if err != nil {
-				fmt.Printf("セッション %s の読み込みに失敗: %v\n", id, err)
+				mlog.Warnf(context.Background(), "セッション %s の読み込みに失敗: %v", id, err)
 				continue
 			}
 			sessions = append(sessions, session)


### PR DESCRIPTION
Refactors SessionDir from being a package global variable to a member field of the Agent struct.

## Changes
- Add sessionDir field to Agent struct with default value ".makasero/sessions"
- Add WithSessionDir() agent option for custom session directories
- Create *FromDir() variants of all session functions
- Add agent methods that use the instance's sessionDir
- Maintain backward compatibility by keeping original global functions

## Benefits
- Better encapsulation (SessionDir no longer global state)
- Each Agent instance can have its own session directory
- Existing code and tests continue to work unchanged

Fixes #70 (partial - refactoring step)

Generated with [Claude Code](https://claude.ai/code)