### PR TITLE
feat: use home directory for session storage by default

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -72,17 +72,11 @@ func NewAgent(ctx context.Context, apiKey string, config *MCPConfig, opts ...Age
 		return nil, fmt.Errorf("API key is required")
 	}
 
-	// デフォルトのセッションディレクトリを設定（ホームディレクトリベース）
-	defaultSessionDir := ".makasero/sessions" // フォールバック
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		defaultSessionDir = filepath.Join(homeDir, ".makasero", "sessions")
-	}
-
 	agent := &Agent{
 		apiKey:     apiKey,
 		modelName:  "gemini-2.0-flash-lite", // default model
 		functions:  make(map[string]FunctionDefinition),
-		sessionDir: defaultSessionDir,
+		sessionDir: SessionDir,
 	}
 
 	for _, opt := range opts {

--- a/agent.go
+++ b/agent.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -70,11 +72,17 @@ func NewAgent(ctx context.Context, apiKey string, config *MCPConfig, opts ...Age
 		return nil, fmt.Errorf("API key is required")
 	}
 
+	// デフォルトのセッションディレクトリを設定（ホームディレクトリベース）
+	defaultSessionDir := ".makasero/sessions" // フォールバック
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		defaultSessionDir = filepath.Join(homeDir, ".makasero", "sessions")
+	}
+
 	agent := &Agent{
 		apiKey:     apiKey,
 		modelName:  "gemini-2.0-flash-lite", // default model
 		functions:  make(map[string]FunctionDefinition),
-		sessionDir: ".makasero/sessions", // default session directory
+		sessionDir: defaultSessionDir,
 	}
 
 	for _, opt := range opts {

--- a/agent.go
+++ b/agent.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 

--- a/session.go
+++ b/session.go
@@ -16,7 +16,18 @@ import (
 
 // SessionDir はセッションファイルを保存するディレクトリパスです。
 // テスト時に変更可能にするためにエクスポートされています。
-var SessionDir = ".makasero/sessions"
+var SessionDir string
+
+func init() {
+	// デフォルトでホームディレクトリの ~/.makasero/sessions を使用
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		// ホームディレクトリが取得できない場合は相対パスにフォールバック
+		SessionDir = ".makasero/sessions"
+		return
+	}
+	SessionDir = filepath.Join(homeDir, ".makasero", "sessions")
+}
 
 const (
 // sessionDir = ".makasero/sessions"


### PR DESCRIPTION
This PR implements the solution for issue #70 by changing the default behavior to use the home directory for session storage instead of the current directory.

## Changes
- Add init() function to session.go to set SessionDir to ~/.makasero/sessions
- Modify agent.go to use home directory for default sessionDir
- Add fallback to current directory if home directory cannot be accessed
- Maintain backward compatibility with existing WithSessionDir() option

## Benefits
- Session files are now unified in ~/.makasero/sessions regardless of execution location
- Environment no longer gets polluted with scattered config files
- Existing WithSessionDir() option continues to work for programmatic overrides

Fixes #70

Generated with [Claude Code](https://claude.ai/code)