### PR TITLE
feat: Show MCP server initialization results only with debug flag

### DIFF
--- a/mcp_manager.go
+++ b/mcp_manager.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/generative-ai-go/genai"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/pankona/makasero/mlog"
 )
 
 type MCPClientManager struct {
@@ -38,7 +39,7 @@ func (m *MCPClientManager) InitializeFromConfig(ctx context.Context, config *MCP
 			return fmt.Errorf("failed to initialize MCP client for %s: %v", serverName, err)
 		}
 
-		fmt.Printf("%s mcp server initialize result: %s\n", serverName, initResult)
+		mlog.Debugf(ctx, "%s mcp server initialize result: %s", serverName, initResult)
 
 		m.clientsLock.Lock()
 		m.clients[serverName] = client


### PR DESCRIPTION
This PR addresses issue #79 by modifying the MCP server initialization output to only display when the debug flag is enabled.

## Changes
- Changed `fmt.Printf` to `mlog.Debugf` for MCP server initialization output
- Added mlog package import
- MCP server list will now only display when `--debug` flag is enabled
- Simplifies normal usage output while preserving debug information

## Testing
```bash
# Normal execution (no output)
./makasero "test prompt"

# Debug execution (shows initialization results)
./makasero --debug "test prompt"
```

Fixes #79

Generated with [Claude Code](https://claude.ai/code)