### PR TITLE
feat: エディタを使った複数行プロンプト入力機能を追加

### DIFF
--- a/cmd/makasero/main.go
+++ b/cmd/makasero/main.go
@@ -51,7 +51,10 @@ func readPromptFromEditor() (string, error) {
 		return "", fmt.Errorf("failed to create temporary file: %v", err)
 	}
 	defer os.Remove(tmpFile.Name())
-	tmpFile.Close()
+	
+	if err := tmpFile.Close(); err != nil {
+		return "", fmt.Errorf("failed to close temporary file %s: %v", tmpFile.Name(), err)
+	}
 
 	cmd := exec.Command(editor, tmpFile.Name())
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
## 概要

makasero CLI にエディタを使った複数行プロンプト入力機能を追加しました。

## 変更内容

- `-e` フラグでエディタを使用したプロンプト入力が可能
- EDITOR環境変数からエディタを自動取得
- 一時ファイルの自動管理（作成・削除）
- エディタ異常終了時のエラーハンドリング
- オプション間の競合チェック機能

Fixes #84

Generated with [Claude Code](https://claude.ai/code)