### PR TITLE
refactor: eliminate XDG path duplication in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # XDG Base Directory for makasero config
-MAKASERO_CONFIG_DIR := $${XDG_CONFIG_HOME:-$$HOME/.config}/makasero
+MAKASERO_CONFIG_DIR := $${XDG_CONFIG_HOME:-$${HOME:?HOME environment variable not set or empty}/.config}/makasero
 
 .PHONY: install install-claude-code
 


### PR DESCRIPTION
Address code review feedback from PR #88 by eliminating duplication of XDG config directory path.

## Changes
- Add MAKASERO_CONFIG_DIR variable at top of Makefile
- Replace repeated shell variable definitions with Makefile variable usage
- Simplify both install and clean targets

## Benefits
- Improved maintainability - path defined in one place
- Reduced code duplication
- Cleaner, more readable Makefile

References #88

Generated with [Claude Code](https://claude.ai/code)